### PR TITLE
Improve disconnect cleanup

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -376,16 +376,11 @@ impl Node {
         state: State,
     ) {
         log::debug!("service responding to broadcast message {:?}", message);
-        // log::debug!("responding to message id {:?}", mid);
         // TODO - This could cause the echo to go to new
         // members who didn't receive the initial
         // broadcast. Make sure they ignore such a message
         // as a benign error.
         let members = state.membership_handle.get_members().await.unwrap();
-        let _ = echo_broadcast_handle
-            .send(message.clone().into(), members)
-            .await;
-
         let protocol_service = protocol::Protocol::new(node_id.clone(), state.clone());
         let echo_broadcast_service =
             EchoBroadcast::new(protocol_service, echo_broadcast_handle, state);

--- a/src/node/echo_broadcast/service.rs
+++ b/src/node/echo_broadcast/service.rs
@@ -66,6 +66,7 @@ where
             let response_message = this.inner.call(msg).await;
             match response_message {
                 Ok(Some(msg)) => {
+                    log::debug!("Sending echo broadcast with message {:?}", msg);
                     let members = this.state.membership_handle.get_members().await.unwrap();
                     if this.handle.send(msg, members).await.is_ok() {
                         Ok(())

--- a/src/node/protocol/handshake.rs
+++ b/src/node/protocol/handshake.rs
@@ -70,12 +70,12 @@ impl Service<Message> for Handshake {
         let local_sender_id = self.sender_id.clone();
         async move {
             match msg {
-                Message::UnicastMessage(Unicast::Handshake(HandshakeMessage {
+                Message::Unicast(Unicast::Handshake(HandshakeMessage {
                     message,
                     sender_id,
                     version,
                 })) => match message.as_str() {
-                    "helo" => Ok(Some(Message::UnicastMessage(super::Unicast::Handshake(
+                    "helo" => Ok(Some(Message::Unicast(super::Unicast::Handshake(
                         HandshakeMessage {
                             message: "oleh".to_string(),
                             sender_id: local_sender_id,
@@ -83,7 +83,7 @@ impl Service<Message> for Handshake {
                         },
                     )))),
                     "oleh" => Ok(None),
-                    _ => Ok(Some(Message::UnicastMessage(super::Unicast::Handshake(
+                    _ => Ok(Some(Message::Unicast(super::Unicast::Handshake(
                         HandshakeMessage {
                             message: "helo".to_string(),
                             sender_id: local_sender_id,
@@ -118,7 +118,7 @@ mod handshake_tests {
         assert!(res.is_some());
         assert_eq!(
             res,
-            Some(Message::UnicastMessage(super::Unicast::Handshake(
+            Some(Message::Unicast(super::Unicast::Handshake(
                 HandshakeMessage {
                     message: "helo".to_string(),
                     sender_id: "local".to_string(),
@@ -137,7 +137,7 @@ mod handshake_tests {
             .ready()
             .await
             .unwrap()
-            .call(Message::UnicastMessage(super::Unicast::Handshake(
+            .call(Message::Unicast(super::Unicast::Handshake(
                 HandshakeMessage {
                     message: "helo".to_string(),
                     sender_id: "local".to_string(),
@@ -149,7 +149,7 @@ mod handshake_tests {
         assert!(res.is_some());
         assert_eq!(
             res,
-            Some(Message::UnicastMessage(super::Unicast::Handshake(
+            Some(Message::Unicast(super::Unicast::Handshake(
                 HandshakeMessage {
                     message: "oleh".to_string(),
                     sender_id: "local".to_string(),
@@ -168,7 +168,7 @@ mod handshake_tests {
             .ready()
             .await
             .unwrap()
-            .call(Message::UnicastMessage(super::Unicast::Handshake(
+            .call(Message::Unicast(super::Unicast::Handshake(
                 HandshakeMessage {
                     message: "oleh".to_string(),
                     sender_id: "local".to_string(),

--- a/src/node/protocol/heartbeat.rs
+++ b/src/node/protocol/heartbeat.rs
@@ -72,11 +72,11 @@ impl Service<Message> for Heartbeat {
         let self_sender_id = self.sender_id.clone();
         async move {
             match msg {
-                Message::UnicastMessage(Unicast::Heartbeat(HeartbeatMessage {
+                Message::Unicast(Unicast::Heartbeat(HeartbeatMessage {
                     sender_id,
                     time,
                 })) => match sender_id.as_str() {
-                    "" => Ok(Some(Message::UnicastMessage(Unicast::Heartbeat(
+                    "" => Ok(Some(Message::Unicast(Unicast::Heartbeat(
                         HeartbeatMessage {
                             time: SystemTime::now(),
                             sender_id: self_sender_id,
@@ -118,7 +118,7 @@ mod heartbeat_tests {
         let mut p = Heartbeat {
             sender_id: "local".to_string(),
         };
-        if let Some(Message::UnicastMessage(Unicast::Heartbeat(msg))) = p
+        if let Some(Message::Unicast(Unicast::Heartbeat(msg))) = p
             .ready()
             .await
             .unwrap()
@@ -141,7 +141,7 @@ mod heartbeat_tests {
             .ready()
             .await
             .unwrap()
-            .call(Message::UnicastMessage(Unicast::Heartbeat(
+            .call(Message::Unicast(Unicast::Heartbeat(
                 HeartbeatMessage {
                     sender_id: "local".to_string(),
                     time: SystemTime::now(),

--- a/src/node/protocol/heartbeat.rs
+++ b/src/node/protocol/heartbeat.rs
@@ -72,18 +72,17 @@ impl Service<Message> for Heartbeat {
         let self_sender_id = self.sender_id.clone();
         async move {
             match msg {
-                Message::Unicast(Unicast::Heartbeat(HeartbeatMessage {
-                    sender_id,
-                    time,
-                })) => match sender_id.as_str() {
-                    "" => Ok(Some(Message::Unicast(Unicast::Heartbeat(
-                        HeartbeatMessage {
-                            time: SystemTime::now(),
-                            sender_id: self_sender_id,
-                        },
-                    )))),
-                    _ => Ok(None),
-                },
+                Message::Unicast(Unicast::Heartbeat(HeartbeatMessage { sender_id, time })) => {
+                    match sender_id.as_str() {
+                        "" => Ok(Some(Message::Unicast(Unicast::Heartbeat(
+                            HeartbeatMessage {
+                                time: SystemTime::now(),
+                                sender_id: self_sender_id,
+                            },
+                        )))),
+                        _ => Ok(None),
+                    }
+                }
                 _ => Ok(None),
             }
         }
@@ -141,12 +140,10 @@ mod heartbeat_tests {
             .ready()
             .await
             .unwrap()
-            .call(Message::Unicast(Unicast::Heartbeat(
-                HeartbeatMessage {
-                    sender_id: "local".to_string(),
-                    time: SystemTime::now(),
-                },
-            )))
+            .call(Message::Unicast(Unicast::Heartbeat(HeartbeatMessage {
+                sender_id: "local".to_string(),
+                time: SystemTime::now(),
+            })))
             .await
             .unwrap();
         assert!(res.is_none());

--- a/src/node/protocol/membership.rs
+++ b/src/node/protocol/membership.rs
@@ -70,7 +70,7 @@ impl Service<Message> for Membership {
         let state = self.state.clone();
         async move {
             match msg {
-                Message::UnicastMessage(Unicast::Membership(MembershipMessage {
+                Message::Unicast(Unicast::Membership(MembershipMessage {
                     message,
                     sender_id,
                 })) => match message {

--- a/src/node/protocol/membership.rs
+++ b/src/node/protocol/membership.rs
@@ -70,28 +70,27 @@ impl Service<Message> for Membership {
         let state = self.state.clone();
         async move {
             match msg {
-                Message::Unicast(Unicast::Membership(MembershipMessage {
-                    message,
-                    sender_id,
-                })) => match message {
-                    None => {
-                        let members = state
-                            .membership_handle
-                            .get_members()
-                            .await
-                            .unwrap()
-                            .into_keys()
-                            .collect();
-                        Ok(Some(
-                            MembershipMessage {
-                                sender_id,
-                                message: Some(members),
-                            }
-                            .into(),
-                        ))
+                Message::Unicast(Unicast::Membership(MembershipMessage { message, sender_id })) => {
+                    match message {
+                        None => {
+                            let members = state
+                                .membership_handle
+                                .get_members()
+                                .await
+                                .unwrap()
+                                .into_keys()
+                                .collect();
+                            Ok(Some(
+                                MembershipMessage {
+                                    sender_id,
+                                    message: Some(members),
+                                }
+                                .into(),
+                            ))
+                        }
+                        _ => Ok(None),
                     }
-                    _ => Ok(None),
-                },
+                }
                 _ => Ok(None),
             }
         }

--- a/src/node/protocol/ping.rs
+++ b/src/node/protocol/ping.rs
@@ -63,7 +63,7 @@ impl Service<Message> for Ping {
         let local_sender_id = self.sender_id.clone();
         async move {
             match msg {
-                Message::UnicastMessage(Unicast::Ping(m)) => match m.message.as_str() {
+                Message::Unicast(Unicast::Ping(m)) => match m.message.as_str() {
                     "" => Ok(Some(
                         PingMessage::new(local_sender_id, "ping".to_string()).into(),
                     )),

--- a/src/node/protocol/round_one_package.rs
+++ b/src/node/protocol/round_one_package.rs
@@ -16,7 +16,7 @@
 // along with Frost-Federation. If not, see
 // <https://www.gnu.org/licenses/>.
 
-use crate::node::protocol::{Broadcast, Message};
+use crate::node::protocol::Message;
 use crate::node::state::State;
 use futures::{Future, FutureExt};
 use serde::{Deserialize, Serialize};
@@ -51,7 +51,7 @@ impl RoundOnePackage {
     }
 }
 
-/// Service for handling RoundOnePackage protocol.
+/// service for handling RoundOnePackage protocol.
 ///
 /// By making all protocol into a Service, we can use tower:Steer to
 /// multiplex across services.
@@ -64,24 +64,12 @@ impl Service<Message> for RoundOnePackage {
         Poll::Ready(Ok(()))
     }
 
+    /// Builds and sends any messages required in response to
+    /// receiving round one package
+    /// For now, there is no response.
     fn call(&mut self, msg: Message) -> Self::Future {
         let state = self.state.clone();
-        async move {
-            match msg {
-                // We receive the package and don't send anything back.
-                Message::BroadcastMessage(Broadcast::RoundOnePackage(_m, Some(_mid))) => Ok(None),
-                // For the first instance of the message, add a message_id
-                Message::BroadcastMessage(Broadcast::RoundOnePackage(m, None)) => {
-                    Ok(Some(Message::BroadcastMessage(Broadcast::RoundOnePackage(
-                        m,
-                        Some(state.message_id_generator.next()),
-                    ))))
-                }
-                // We shouldn't receive round one package as a unicast
-                Message::UnicastMessage(_) => Err("Round one package should not be unicast".into()),
-            }
-        }
-        .boxed()
+        async move { Ok(None) }.boxed()
     }
 }
 
@@ -93,33 +81,8 @@ mod round_one_package_tests {
     use crate::node::protocol::{Message, RoundOnePackageMessage};
     use crate::node::state::State;
     use crate::node::MessageIdGenerator;
-    use crate::node::{membership::MembershipHandle, protocol::Broadcast};
+    use crate::node::{membership::MembershipHandle, protocol::BroadcastProtocol};
     use tower::{Service, ServiceExt};
-
-    #[tokio::test]
-    async fn it_should_create_round_one_package_as_service_and_respond_to_none_with_round_one_package(
-    ) {
-        let message_id_generator = MessageIdGenerator::new("localhost".to_string());
-        let membership_handle = MembershipHandle::start("localhost".to_string()).await;
-        let state = State::new(membership_handle, message_id_generator);
-
-        let mut p = RoundOnePackage::new("local".into(), state);
-        let res = p
-            .ready()
-            .await
-            .unwrap()
-            .call(RoundOnePackageMessage::default().into())
-            .await
-            .unwrap();
-        assert!(res.is_some());
-        let Message::BroadcastMessage(Broadcast::RoundOnePackage(m, mid)) = res.unwrap() else {
-            todo!("nothing here");
-        };
-        assert_eq!(
-            m,
-            RoundOnePackageMessage::new("".to_string(), "".to_string())
-        );
-    }
 
     #[tokio::test]
     async fn it_should_create_round_one_package_as_service_and_respond_to_round_one_package_with_none(
@@ -133,10 +96,13 @@ mod round_one_package_tests {
             .ready()
             .await
             .unwrap()
-            .call(Message::BroadcastMessage(Broadcast::RoundOnePackage(
-                RoundOnePackageMessage::new("local".to_string(), "round_one_package".to_string()),
+            .call(Message::Broadcast(
+                BroadcastProtocol::RoundOnePackage(RoundOnePackageMessage::new(
+                    "local".to_string(),
+                    "round_one_package".to_string(),
+                )),
                 Some(MessageId(1)),
-            )))
+            ))
             .await
             .unwrap();
         assert!(res.is_none());


### PR DESCRIPTION
Message/Unicast/Broadcast/Echo were re-organised. Got rid of untagged,
so we are more precise with the serde.

Using peer_addr received from connection to track echos.