### PR TITLE
Streamline round timeouts

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -126,10 +126,19 @@ impl Node {
         log::debug!("Starting... {}", self.bind_address);
         let node_id = self.get_node_id().clone();
         let state = self.state.clone();
+        let (round_tx, round_rx) = mpsc::channel::<()>(1);
+        self.state.round_tx = Some(round_tx.clone());
         let echo_broadcast_handle = self.echo_broadcast_handle.clone();
-        // let interval = tokio::time::interval(tokio::time::Duration::from_secs(15));
         tokio::spawn(async move {
-            dkg::trigger::run_dkg_trigger(15000, node_id, state, echo_broadcast_handle, None).await;
+            dkg::trigger::run_dkg_trigger(
+                15000,
+                node_id,
+                state,
+                echo_broadcast_handle,
+                None,
+                round_rx,
+            )
+            .await;
         });
 
         if self.connect_to_seeds().await.is_err() {

--- a/src/node.rs
+++ b/src/node.rs
@@ -125,12 +125,15 @@ impl Node {
     ) {
         log::debug!("Starting... {}", self.bind_address);
         let node_id = self.get_node_id().clone();
-        let state = self.state.clone();
-        let (round_one_tx, round_one_rx) = mpsc::channel::<()>(1);
-        self.state.round_one_tx = Some(round_one_tx.clone());
-        let (round_two_tx, round_two_rx) = mpsc::channel::<()>(1);
-        self.state.round_two_tx = Some(round_two_tx.clone());
         let echo_broadcast_handle = self.echo_broadcast_handle.clone();
+
+        // We can send message on the channel from both sending and receiving tasks
+        let (round_one_tx, round_one_rx) = mpsc::channel::<()>(2);
+        self.state.round_one_tx = Some(round_one_tx);
+        let (round_two_tx, round_two_rx) = mpsc::channel::<()>(2);
+        self.state.round_two_tx = Some(round_two_tx);
+
+        let state = self.state.clone();
         tokio::spawn(async move {
             dkg::trigger::run_dkg_trigger(
                 15000,

--- a/src/node.rs
+++ b/src/node.rs
@@ -126,8 +126,10 @@ impl Node {
         log::debug!("Starting... {}", self.bind_address);
         let node_id = self.get_node_id().clone();
         let state = self.state.clone();
-        let (round_tx, round_rx) = mpsc::channel::<()>(1);
-        self.state.round_tx = Some(round_tx.clone());
+        let (round_one_tx, round_one_rx) = mpsc::channel::<()>(1);
+        self.state.round_one_tx = Some(round_one_tx.clone());
+        let (round_two_tx, round_two_rx) = mpsc::channel::<()>(1);
+        self.state.round_two_tx = Some(round_two_tx.clone());
         let echo_broadcast_handle = self.echo_broadcast_handle.clone();
         tokio::spawn(async move {
             dkg::trigger::run_dkg_trigger(
@@ -136,7 +138,8 @@ impl Node {
                 state,
                 echo_broadcast_handle,
                 None,
-                round_rx,
+                round_one_rx,
+                round_two_rx,
             )
             .await;
         });

--- a/src/node/echo_broadcast/mod.rs
+++ b/src/node/echo_broadcast/mod.rs
@@ -227,7 +227,11 @@ impl EchoBroadcastActor {
 
     /// Check if echos have been received from all members for a given message identifier
     pub fn echo_received_for_all(&self, message_id: &MessageId) -> bool {
-        log::debug!("{:?}", self.message_echos);
+        log::debug!(
+            "Checking for echos for message id {:?}, {:?}",
+            message_id,
+            self.message_echos
+        );
         self.message_echos
             .get(message_id)
             .unwrap()

--- a/src/node/protocol/dkg/round_one.rs
+++ b/src/node/protocol/dkg/round_one.rs
@@ -140,11 +140,15 @@ impl Service<Message> for Package {
                         message
                     );
                     let identifier = frost::Identifier::derive(from_sender_id.as_bytes()).unwrap();
-                    state
+                    let finished = state
                         .dkg_state
                         .add_round1_package(identifier, message)
                         .await
                         .unwrap();
+                    if finished {
+                        log::debug!("Round one finished, sending signal");
+                        let _ = state.round_tx.unwrap().send(()).await;
+                    }
                     Ok(None)
                 }
                 _ => {

--- a/src/node/protocol/dkg/round_one.rs
+++ b/src/node/protocol/dkg/round_one.rs
@@ -147,7 +147,7 @@ impl Service<Message> for Package {
                         .unwrap();
                     if finished {
                         log::debug!("Round one finished, sending signal");
-                        let _ = state.round_tx.unwrap().send(()).await;
+                        let _ = state.round_one_tx.unwrap().send(()).await;
                     }
                     Ok(None)
                 }

--- a/src/node/protocol/dkg/round_two.rs
+++ b/src/node/protocol/dkg/round_two.rs
@@ -163,7 +163,7 @@ impl Service<Message> for Package {
                         .unwrap();
                     if finished {
                         log::debug!("Round two finished, sending signal");
-                        let _ = state.round_tx.unwrap().send(()).await;
+                        let _ = state.round_two_tx.unwrap().send(()).await;
                     }
                     Ok(None)
                 }

--- a/src/node/protocol/dkg/trigger.rs
+++ b/src/node/protocol/dkg/trigger.rs
@@ -131,10 +131,10 @@ pub(crate) async fn trigger_dkg(
     // TODO Improve this to allow round1 to finish as soon as all other parties have sent their round1 message
     // This will mean moving the timeout into round1 service
 
-    // Wait for round1 to finish, give it 5 seconds
-    if round1_future.await.is_err() {
-        log::error!("Error running round 1");
-        return Err("Error running round 1".into());
+    // Start round1
+    if let Err(e) = round1_future.await {
+        log::error!("Error running round 1: {:?}", e);
+        return Err("Error running round 1: failed with error".into());
     }
     round_one_rx.recv().await.unwrap();
     log::info!("Round 1 finished");
@@ -149,9 +149,9 @@ pub(crate) async fn trigger_dkg(
     );
 
     // start round2
-    if round2_future.await.is_err() {
-        log::error!("Error running round 2");
-        return Err("Error running round 2".into());
+    if let Err(e) = round2_future.await {
+        log::error!("Error running round 2: {:?}", e);
+        return Err("Error running round 2: failed with error".into());
     }
     round_two_rx.recv().await.unwrap();
     log::info!("Round 2 finished");

--- a/src/node/reliable_sender/mod.rs
+++ b/src/node/reliable_sender/mod.rs
@@ -165,7 +165,6 @@ async fn start_reliable_sender(mut actor: ReliableSenderActor) {
             connection_msg = actor.connection_receiver.recv() => {
                 match connection_msg {
                     Some(msg) => {
-                        log::debug!("Received message from connection {:?}", msg);
                         if let Err(e) = actor.handle_connection_message(msg).await {
                             log::info!("Error handling received message. Shutting down. {}", e);
                             return

--- a/src/node/state.rs
+++ b/src/node/state.rs
@@ -19,13 +19,14 @@
 use crate::node::membership::MembershipHandle;
 use crate::node::protocol::dkg;
 use crate::node::protocol::message_id_generator::MessageIdGenerator;
-
+use tokio::sync::mpsc;
 /// Handlers to query/update node state
 #[derive(Clone)]
 pub(crate) struct State {
     pub(crate) membership_handle: MembershipHandle,
     pub(crate) message_id_generator: MessageIdGenerator,
     pub(crate) dkg_state: dkg::state::StateHandle,
+    pub(crate) round_tx: Option<mpsc::Sender<()>>,
 }
 
 impl State {
@@ -38,6 +39,7 @@ impl State {
             membership_handle,
             message_id_generator,
             dkg_state: dkg::state::StateHandle::new(Some(expected_members)),
+            round_tx: None,
         }
     }
 

--- a/src/node/state.rs
+++ b/src/node/state.rs
@@ -26,7 +26,8 @@ pub(crate) struct State {
     pub(crate) membership_handle: MembershipHandle,
     pub(crate) message_id_generator: MessageIdGenerator,
     pub(crate) dkg_state: dkg::state::StateHandle,
-    pub(crate) round_tx: Option<mpsc::Sender<()>>,
+    pub(crate) round_one_tx: Option<mpsc::Sender<()>>,
+    pub(crate) round_two_tx: Option<mpsc::Sender<()>>,
 }
 
 impl State {
@@ -39,7 +40,8 @@ impl State {
             membership_handle,
             message_id_generator,
             dkg_state: dkg::state::StateHandle::new(Some(expected_members)),
-            round_tx: None,
+            round_one_tx: None,
+            round_two_tx: None,
         }
     }
 


### PR DESCRIPTION
No more sleeps! 

In the best case outcome, we end round as soon as messages from all parties have been received.

If some fail, we wait for the timeout to expire and the rounds take longer then. The round period is a constant atm, can move this to config, if needed. 